### PR TITLE
add kubesphere prefix to rbac resource names

### DIFF
--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -33,9 +33,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local clusterRoleBinding = k.rbac.v1.clusterRoleBinding;
 
       clusterRoleBinding.new() +
-      clusterRoleBinding.mixin.metadata.withName('kube-state-metrics') +
+      clusterRoleBinding.mixin.metadata.withName('kubesphere-kube-state-metrics') +
       clusterRoleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
-      clusterRoleBinding.mixin.roleRef.withName('kube-state-metrics') +
+      clusterRoleBinding.mixin.roleRef.withName('kubesphere-kube-state-metrics') +
       clusterRoleBinding.mixin.roleRef.mixinInstance({ kind: 'ClusterRole' }) +
       clusterRoleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'kube-state-metrics', namespace: $._config.namespace }]),
 
@@ -120,7 +120,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local rules = [coreRule, extensionsRule, appsRule, batchRule, autoscalingRule, authenticationRole, authorizationRole, policyRule];
 
       clusterRole.new() +
-      clusterRole.mixin.metadata.withName('kube-state-metrics') +
+      clusterRole.mixin.metadata.withName('kubesphere-kube-state-metrics') +
       clusterRole.withRules(rules),
     deployment:
       local deployment = k.apps.v1beta2.deployment;

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -20,9 +20,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local clusterRoleBinding = k.rbac.v1.clusterRoleBinding;
 
       clusterRoleBinding.new() +
-      clusterRoleBinding.mixin.metadata.withName('node-exporter') +
+      clusterRoleBinding.mixin.metadata.withName('kubesphere-node-exporter') +
       clusterRoleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
-      clusterRoleBinding.mixin.roleRef.withName('node-exporter') +
+      clusterRoleBinding.mixin.roleRef.withName('kubesphere-node-exporter') +
       clusterRoleBinding.mixin.roleRef.mixinInstance({ kind: 'ClusterRole' }) +
       clusterRoleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'node-exporter', namespace: $._config.namespace }]),
 
@@ -47,7 +47,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local rules = [authenticationRole, authorizationRole];
 
       clusterRole.new() +
-      clusterRole.mixin.metadata.withName('node-exporter') +
+      clusterRole.mixin.metadata.withName('kubesphere-node-exporter') +
       clusterRole.withRules(rules),
 
     daemonset:

--- a/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/contrib/kube-prometheus/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -131,7 +131,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local rules = [nodeMetricsRule, metricsRule];
 
       clusterRole.new() +
-      clusterRole.mixin.metadata.withName('prometheus-' + $._config.prometheus.name) +
+      clusterRole.mixin.metadata.withName('kubesphere-prometheus-' + $._config.prometheus.name) +
       clusterRole.withRules(rules),
     roleConfig:
       local role = k.rbac.v1.role;
@@ -162,9 +162,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local clusterRoleBinding = k.rbac.v1.clusterRoleBinding;
 
       clusterRoleBinding.new() +
-      clusterRoleBinding.mixin.metadata.withName('prometheus-' + $._config.prometheus.name) +
+      clusterRoleBinding.mixin.metadata.withName('kubesphere-prometheus-' + $._config.prometheus.name) +
       clusterRoleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
-      clusterRoleBinding.mixin.roleRef.withName('prometheus-' + $._config.prometheus.name) +
+      clusterRoleBinding.mixin.roleRef.withName('kubesphere-prometheus-' + $._config.prometheus.name) +
       clusterRoleBinding.mixin.roleRef.mixinInstance({ kind: 'ClusterRole' }) +
       clusterRoleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'prometheus-' + $._config.prometheus.name, namespace: $._config.namespace }]),
     prometheus:

--- a/contrib/kube-prometheus/jsonnetfile.lock.json
+++ b/contrib/kube-prometheus/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "contrib/kube-prometheus/jsonnet/kube-prometheus"
                 }
             },
-            "version": "0975ba408b4bf1a4e4ce7469a2633195985eee60"
+            "version": "9fe63e5a013c3d24cc908ea372da33f8d3c819c1"
         },
         {
             "name": "ksonnet",

--- a/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRole.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kube-state-metrics
+  name: kubesphere-kube-state-metrics
 rules:
 - apiGroups:
   - ""

--- a/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRoleBinding.yaml
+++ b/contrib/kube-prometheus/manifests/kube-state-metrics-clusterRoleBinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kube-state-metrics
+  name: kubesphere-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kube-state-metrics
+  name: kubesphere-kube-state-metrics
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics

--- a/contrib/kube-prometheus/manifests/node-exporter-clusterRole.yaml
+++ b/contrib/kube-prometheus/manifests/node-exporter-clusterRole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: node-exporter
+  name: kubesphere-node-exporter
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/contrib/kube-prometheus/manifests/node-exporter-clusterRoleBinding.yaml
+++ b/contrib/kube-prometheus/manifests/node-exporter-clusterRoleBinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: node-exporter
+  name: kubesphere-node-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: node-exporter
+  name: kubesphere-node-exporter
 subjects:
 - kind: ServiceAccount
   name: node-exporter

--- a/contrib/kube-prometheus/manifests/prometheus-clusterRole.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-clusterRole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus-k8s
+  name: kubesphere-prometheus-k8s
 rules:
 - apiGroups:
   - ""

--- a/contrib/kube-prometheus/manifests/prometheus-clusterRoleBinding.yaml
+++ b/contrib/kube-prometheus/manifests/prometheus-clusterRoleBinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-k8s
+  name: kubesphere-prometheus-k8s
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-k8s
+  name: kubesphere-prometheus-k8s
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s

--- a/jsonnet/prometheus-operator/prometheus-operator.libsonnet
+++ b/jsonnet/prometheus-operator/prometheus-operator.libsonnet
@@ -28,9 +28,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local clusterRoleBinding = k.rbac.v1.clusterRoleBinding;
 
       clusterRoleBinding.new() +
-      clusterRoleBinding.mixin.metadata.withName('prometheus-operator') +
+      clusterRoleBinding.mixin.metadata.withName('kubesphere-prometheus-operator') +
       clusterRoleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
-      clusterRoleBinding.mixin.roleRef.withName('prometheus-operator') +
+      clusterRoleBinding.mixin.roleRef.withName('kubesphere-prometheus-operator') +
       clusterRoleBinding.mixin.roleRef.mixinInstance({ kind: 'ClusterRole' }) +
       clusterRoleBinding.withSubjects([{ kind: 'ServiceAccount', name: 'prometheus-operator', namespace: $._config.namespace }]),
 
@@ -104,7 +104,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local rules = [apiExtensionsRule, monitoringRule, appsRule, coreRule, podRule, routingRule, nodeRule, namespaceRule];
 
       clusterRole.new() +
-      clusterRole.mixin.metadata.withName('prometheus-operator') +
+      clusterRole.mixin.metadata.withName('kubesphere-prometheus-operator') +
       clusterRole.withRules(rules),
 
     deployment:


### PR DESCRIPTION
This PR is to avoid rbac resource naming conflicts in environments such as Openshift